### PR TITLE
queue: Fix the overflow error

### DIFF
--- a/Source Code/Source/queue.c
+++ b/Source Code/Source/queue.c
@@ -18,7 +18,7 @@ int enqueue_all(QUEUE * queue, uint8_t *data,uint16_t size)
 {
 	if((queue->tail+size)  >= queue->size)
 	{
-		uint16_t len=size-queue->tail;
+		uint16_t len=queue->size-queue->tail;
 		memcpy(&queue->data[queue->tail],data,len);
 		size -=len;
 		if(size>=queue->head) size=queue->head-1;


### PR DESCRIPTION
There will be a segment fault once the queue has been
written over max length of the queue because of the last write length to the queue.
The calculated length for copying data from head to queue->tail is incorrect which will lead a segment fault inside the memcpy().